### PR TITLE
Correct install package from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Broadcast Channel API allows sending messages to other browsing contexts on 
 
 1. Install the NuGet package `Blazor.BroadcastChannel`.
     ```
-    dotnet add Blazor.BroadcastChannel 
+    dotnet add package Blazor.BroadcastChannel 
     ```
 2. In `Program.cs` add `builder.Services.AddBroadcastChannel`.
     ```


### PR DESCRIPTION
Installing package from CLI should be `dotnet add package Blazor.BroadcastChannel`